### PR TITLE
Fix solution misconfiruration for Windows x64

### DIFF
--- a/src/FastFind.sln
+++ b/src/FastFind.sln
@@ -26,10 +26,10 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{87F4C1AF-9E68-448D-8410-AFE92F63E667}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{87F4C1AF-9E68-448D-8410-AFE92F63E667}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{87F4C1AF-9E68-448D-8410-AFE92F63E667}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{87F4C1AF-9E68-448D-8410-AFE92F63E667}.Release|Any CPU.Build.0 = Release|Any CPU
+		{87F4C1AF-9E68-448D-8410-AFE92F63E667}.Debug|Any CPU.ActiveCfg = Debug|x64
+		{87F4C1AF-9E68-448D-8410-AFE92F63E667}.Debug|Any CPU.Build.0 = Debug|x64
+		{87F4C1AF-9E68-448D-8410-AFE92F63E667}.Release|Any CPU.ActiveCfg = Release|x64
+		{87F4C1AF-9E68-448D-8410-AFE92F63E667}.Release|Any CPU.Build.0 = Release|x64
 		{5A62C4AA-3938-4816-9B92-FAA6332C897D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{5A62C4AA-3938-4816-9B92-FAA6332C897D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5A62C4AA-3938-4816-9B92-FAA6332C897D}.Release|Any CPU.ActiveCfg = Release|Any CPU


### PR DESCRIPTION
Added mapping AnyCPU to x64 for FastFind.Windows.csproj to make solution successfully compile on Windows x64.